### PR TITLE
changed common logs logic using regex pattern matching

### DIFF
--- a/eks-log-collector.sh
+++ b/eks-log-collector.sh
@@ -58,16 +58,15 @@ COMMON_DIRECTORIES=(
   cni # eks
 )
 
-# Defines COMMON_LOGS in regex pattern 
 COMMON_LOGS=(
-  ^syslog
-  ^messages
-  ^aws-routed-eni # eks
-  ^containers # eks
-  ^pods # eks
-  ^cloud-init.log
-  ^cloud-init-output.log
-  ^kube-proxy* # kube-proxy and all of its rotated logs
+  syslog
+  messages
+  aws-routed-eni # eks
+  containers # eks
+  pods # eks
+  cloud-init.log
+  cloud-init-output.log
+  kube-proxy.log
 )
 
 # L-IPAMD introspection data points
@@ -286,12 +285,9 @@ get_common_logs() {
   try "collect common operating system logs"
 
   for entry in ${COMMON_LOGS[*]}; do
-    # using grep regex pattern prevents error when a file pattern is not found.
-    # support multiple file selection matching the pattern
-    files=`ls /var/log/ | grep "${entry}"`
-    for file in ${files[*]}; do
-      cp --force --recursive --dereference "/var/log/${file}" "${COLLECT_DIR}"/var_log/
-    done
+    if [[ -e "/var/log/${entry}" ]]; then
+      cp --force --recursive --dereference /var/log/"${entry}" "${COLLECT_DIR}"/var_log/
+    fi
   done
 
   ok


### PR DESCRIPTION
I changed the logic for common logic selection to use regex pattern matching, By doing this we will be able to select multiple files that have the same pattern. For example kube-proxy log. As per your, I have tested this modification on:

Kubernetes cluster created by EKS console 
- v1.11 ami-0c5b63ec54dd3fc38 (us-east-1)
- v1.10 ami-0a3df91af7c8225db (ap-southeast-1)

Kubernetes cluster created by eksctl
- v1.11 ami-0b10ebfc82e446296 (us-east-2)
- v1.10 ami-0d885462fa1a40e3a (us-east-2)
